### PR TITLE
v2.0.0 Refine Spanish Layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Cyan indicator LED on left ALT to indicate that Spanish layers are active
+- Cyan indicator LED on left ALT to indicate that the Spanish layer is active
 
 ### Changed
 
-- Spanish layers are no longer toggled by holding `CAPS LOCK`. Instead, Spanish layers are turned on and off by
+- Spanish layers merged into a single layer
+- Spanish layer is no longer toggled by holding `CAPS LOCK`. Instead, the Spanish layer is turned on and off by
   double tapping left ALT.
+- The Spanish layer is automatically turned off after typing a Spanish letter
 - README to reflect changes
 
 ## [1.3.0] - 2025-01-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2025-01-21
+
+### Added
+
+- Cyan indicator LED on left ALT to indicate that Spanish layers are active
+
+### Changed
+
+- Spanish layers are no longer toggled by holding `CAPS LOCK`. Instead, Spanish layers are turned on and off by
+  double tapping left ALT.
+- README to reflect changes
+
 ## [1.3.0] - 2025-01-20
 
 ### Added
@@ -46,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file
 - gitignore
 
+[2.0.0]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v1.3.0...v2.0.0
 [1.3.0]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v1.0.0...v1.1.0

--- a/README.md
+++ b/README.md
@@ -13,17 +13,21 @@ keyboard like so:
 
 ### Spanish Language Support
 
+The Spanish layers can be turned on and off by double tapping `LEFT ALT`. While the Spanish layers are active, the
+`LEFT ALT` key will be back lit with a cyan LED.
+
 #### Letters with Accents
 
-Spanish letters with accents can be typed by holding down `CAPS LOCK` and pressing the corresponding letter.
-For example, pressing `a` will produce `á`, `e` will produce `é`, `n` will produce `ñ` and so on.
-To get capital letters, hold both `CAPS LOCK` and `LEFT SHIFT` at the same time.
+While the Spanish layers are active, type the corresponding letter. For example, pressing `a` will produce `á`,
+`e` will produce `é`, `n` will produce `ñ` and so on. To get capital letters, hold `LEFT SHIFT` at the same time as
+pressing the corresponding letter.
 
 #### Inverted Punctuation Marks
-For `¡` and `¿`, use `CAPS LOCK`+`LEFT SHIFT`+`1` and `CAPS LOCK`+`LEFT SHIFT`+`/`, respectively.
+
+For `¡` and `¿`,  use `LEFT SHIFT`+`1` and `LEFT SHIFT`+`/`, respectively.
 
 Note that `SHIFT`+`1` is `!` and `SHIFT`+`/` is `?`, so effectively, you could also think of these as
-`CAPS LOCK`+`!` and `CAPS LOCK`+`?`, respectively.
+just pressing `!` and `?`, respectively, while the Spanish layer is active.
 
 ## Compiling
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,26 @@ keyboard like so:
 
 ![numpad.png](numpad.png)
 
+While the numpad layer is active, the numpad keys are backlit with cyan LEDs.
+
 ### Spanish Language Support
 
-The Spanish layers can be turned on and off by double tapping `LEFT ALT`. While the Spanish layers are active, the
-`LEFT ALT` key will be back lit with a cyan LED.
+The Spanish layer can be turned on and off by double tapping `LEFT ALT`. While the Spanish layer is active, the
+`LEFT ALT` key will be backlit with a cyan LED. The Spanish layer is automatically turned off after typing a 
+Spanish letter.
 
 #### Letters with Accents
 
-While the Spanish layers are active, type the corresponding letter. For example, pressing `a` will produce `á`,
-`e` will produce `é`, `n` will produce `ñ` and so on. To get capital letters, hold `LEFT SHIFT` at the same time as
+While the Spanish layer is active, type the corresponding letter. For example, pressing `a` will produce `á`,
+`e` will produce `é`, `n` will produce `ñ` and so on. To get capital letters, hold `SHIFT` at the same time as
 pressing the corresponding letter.
 
 #### Inverted Punctuation Marks
 
-For `¡` and `¿`,  use `LEFT SHIFT`+`1` and `LEFT SHIFT`+`/`, respectively.
+For `¡` and `¿`,  use `SHIFT`+`1` and `SHIFT`+`/`, respectively.
 
 Note that `SHIFT`+`1` is `!` and `SHIFT`+`/` is `?`, so effectively, you could also think of these as
-just pressing `!` and `?`, respectively, while the Spanish layer is active.
+just pressing `!` and `?`, while the Spanish layer is active.
 
 ## Compiling
 

--- a/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/keymap.c
+++ b/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/keymap.c
@@ -8,6 +8,10 @@
 extern rgb_config_t rgb_matrix_config;
 bool rgb_enabled_flag;                  // Current LED state flag. If false then LED is off.
 
+enum tapdance_keycodes {
+    TD_ALT_ES = 0 // Tap dance key to switch to Spanish layer
+};
+
 enum ctrl_keycodes {
     U_T_AUTO = SAFE_RANGE, //USB Extra Port Toggle Auto Detect / Always Active
     U_T_AGCR,              //USB Toggle Automatic GCR control
@@ -36,14 +40,19 @@ enum custom_keycodes {
     INV_QUS                 // Inverted question mark
 };
 
+// Associate our tap dance key with its functionality
+tap_dance_action_t tap_dance_actions[] = {
+    [TD_ALT_ES] = ACTION_TAP_DANCE_LAYER_TOGGLE(KC_LALT, 3)
+};
+
 const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
     [0] = LAYOUT(
-        KC_ESC,        KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,             KC_PSCR, KC_SCRL, KC_PAUS,
-        LT(2,KC_GRV),  KC_1,    KC_2,    KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,   KC_INS,  KC_HOME, KC_PGUP,
-        KC_TAB,        KC_Q,    KC_W,    KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,   KC_DEL,  KC_END,  KC_PGDN,
-        LT(3,KC_CAPS), KC_A,    KC_S,    KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
-        KC_LSFT,       KC_Z,    KC_X,    KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                              KC_UP,
-        KC_LCTL,       KC_LGUI, KC_LALT,                   KC_SPC,                             KC_RALT, MO(1),   KC_APP,  KC_RCTL,            KC_LEFT, KC_DOWN, KC_RGHT
+        KC_ESC,       KC_F1,   KC_F2,         KC_F3,   KC_F4,   KC_F5,   KC_F6,   KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,             KC_PSCR, KC_SCRL, KC_PAUS,
+        LT(2,KC_GRV), KC_1,    KC_2,          KC_3,    KC_4,    KC_5,    KC_6,    KC_7,    KC_8,    KC_9,    KC_0,    KC_MINS, KC_EQL,  KC_BSPC,   KC_INS,  KC_HOME, KC_PGUP,
+        KC_TAB,       KC_Q,    KC_W,          KC_E,    KC_R,    KC_T,    KC_Y,    KC_U,    KC_I,    KC_O,    KC_P,    KC_LBRC, KC_RBRC, KC_BSLS,   KC_DEL,  KC_END,  KC_PGDN,
+        KC_CAPS,      KC_A,    KC_S,          KC_D,    KC_F,    KC_G,    KC_H,    KC_J,    KC_K,    KC_L,    KC_SCLN, KC_QUOT, KC_ENT,
+        KC_LSFT,      KC_Z,    KC_X,          KC_C,    KC_V,    KC_B,    KC_N,    KC_M,    KC_COMM, KC_DOT,  KC_SLSH, KC_RSFT,                              KC_UP,
+        KC_LCTL,      KC_LGUI, TD(TD_ALT_ES),                   KC_SPC,                             KC_RALT, MO(1),   KC_APP,  KC_RCTL,            KC_LEFT, KC_DOWN, KC_RGHT
     ),
     [1] = LAYOUT(
         _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,            KC_MUTE, _______, _______,
@@ -120,7 +129,7 @@ const uint8_t PROGMEM ledmap[][RGB_MATRIX_LED_COUNT][3] = {
         BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
         BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
         BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,                      BLACK,
-        BLACK, BLACK, BLACK,               BLACK,                      BLACK, BLACK, BLACK, BLACK,        BLACK, BLACK, BLACK,
+        BLACK, BLACK, CYAN,                BLACK,                      BLACK, BLACK, BLACK, BLACK,        BLACK, BLACK, BLACK,
         // Boarder; starts bottom right and moves clockwise
         DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED,
         DIM_RED, DIM_WHITE, DIM_RED,
@@ -133,7 +142,7 @@ const uint8_t PROGMEM ledmap[][RGB_MATRIX_LED_COUNT][3] = {
         BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
         BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
         BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,                      BLACK,
-        BLACK, BLACK, BLACK,               BLACK,                      BLACK, BLACK, BLACK, BLACK,        BLACK, BLACK, BLACK,
+        BLACK, BLACK, CYAN,                BLACK,                      BLACK, BLACK, BLACK, BLACK,        BLACK, BLACK, BLACK,
         // Boarder; starts bottom right and moves clockwise
         DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED,
         DIM_RED, DIM_WHITE, DIM_RED,
@@ -300,7 +309,6 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
             return true; //Process all other keycodes normally
     }
 }
-
 
 void set_layer_color(int layer) {
     for (int i = 0; i < RGB_MATRIX_LED_COUNT; i++) {

--- a/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/keymap.c
+++ b/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/keymap.c
@@ -24,20 +24,14 @@ enum ctrl_keycodes {
 
 enum custom_keycodes {
     // The start of this enum should always be equal to end of ctrl_keycodes + 1
-    A_AC_LOW = MD_BOOT + 1, // Lowercase a with acute accent
-    A_AC_CAP,               // Uppercase A with acute accent
-    E_AC_LOW,               // Lowercase e with acute accent
-    E_AC_CAP,               // Uppercase E with acute accent
-    I_AC_LOW,               // Lowercase i with acute accent
-    I_AC_CAP,               // Uppercase I with acute accent
-    O_AC_LOW,               // Lowercase o with acute accent
-    O_AC_CAP,               // Uppercase O with acute accent
-    U_AC_LOW,               // Lowercase u with acute accent
-    U_AC_CAP,               // Uppercase U with acute accent
-    ENE_LOW,                // Lowercase n with tilde accent
-    ENE_CAP,                // Uppercase N with tilde accent
-    INV_EXC,                // Inverted exclamation point
-    INV_QUS                 // Inverted question mark
+    A_ACUTE = MD_BOOT + 1, // A with acute accent
+    E_ACUTE,               // E with acute accent
+    I_ACUTE,               // I with acute accent
+    O_ACUTE,               // O with acute accent
+    U_ACUTE,               // U with acute accent
+    ENE,                   // N with tilde accent
+    INV_EXC,               // Inverted exclamation point
+    INV_QUS                // Inverted question mark
 };
 
 // Associate our tap dance key with its functionality
@@ -71,20 +65,12 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
         _______, _______, _______,                   _______,                            _______, _______, _______, _______,            _______, _______, _______
     ),
     [3] = LAYOUT(
-        _______,       _______,  _______, _______,  _______, _______, _______, _______,  _______,  _______,  _______, _______, _______,            _______, _______, _______,
-        _______,       _______,  _______, _______,  _______, _______, _______, _______,  _______,  _______,  _______, _______, _______, _______,   _______, _______, _______,
-        _______,       _______,  _______, E_AC_LOW, _______, _______, _______, U_AC_LOW, I_AC_LOW, O_AC_LOW, _______, _______, _______, _______,   _______, _______, _______,
-        _______,       A_AC_LOW, _______, _______,  _______, _______, _______, _______,  _______,  _______,  _______, _______, _______,
-        LT(4,KC_TRNS), _______,  _______, _______,  _______, _______, ENE_LOW, _______,  _______,  _______,  _______, _______,                              _______,
-        _______,       _______,  _______,                    _______,                              _______,  _______, _______, _______,            _______, _______, _______
-    ),
-    [4] = LAYOUT(
-        _______,       _______,  _______, _______,  _______, _______, _______, _______,  _______,  _______,  _______, _______, _______,            _______, _______, _______,
-        _______,       INV_EXC,  _______, _______,  _______, _______, _______, _______,  _______,  _______,  _______, _______, _______, _______,   _______, _______, _______,
-        _______,       _______,  _______, E_AC_CAP, _______, _______, _______, U_AC_CAP, I_AC_CAP, O_AC_CAP, _______, _______, _______, _______,   _______, _______, _______,
-        _______,       A_AC_CAP, _______, _______,  _______, _______, _______, _______,  _______,  _______,  _______, _______, _______,
-        _______,       _______,  _______, _______,  _______, _______, ENE_CAP, _______,  _______,  _______,  INV_QUS, _______,                              _______,
-        _______,       _______,  _______,                    _______,                              _______,  _______, _______, _______,            _______, _______, _______
+        _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,          _______, _______, _______,
+        _______, INV_EXC, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, E_ACUTE, _______, _______, _______, U_ACUTE, I_ACUTE, O_ACUTE, _______, _______, _______, _______, _______, _______, _______,
+        _______, A_ACUTE, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______, _______,
+        _______, _______, _______, _______, _______, _______, ENE,     _______, _______, _______, INV_QUS, _______,                            _______,
+        _______, _______, _______,                   _______,                            _______, _______, _______, _______,          _______, _______, _______
     )
 };
 
@@ -135,19 +121,6 @@ const uint8_t PROGMEM ledmap[][RGB_MATRIX_LED_COUNT][3] = {
         DIM_RED, DIM_WHITE, DIM_RED,
         DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED,
         DIM_RED, DIM_WHITE, DIM_RED
-    },
-    [4] = {
-        BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,        BLACK, BLACK, BLACK,
-        BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
-        BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
-        BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,
-        BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK, BLACK,                      BLACK,
-        BLACK, BLACK, CYAN,                BLACK,                      BLACK, BLACK, BLACK, BLACK,        BLACK, BLACK, BLACK,
-        // Boarder; starts bottom right and moves clockwise
-        DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED,
-        DIM_RED, DIM_WHITE, DIM_RED,
-        DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED, DIM_RED, DIM_WHITE, DIM_RED, DIM_RED,
-        DIM_RED, DIM_WHITE, DIM_RED
     }
 };
 
@@ -165,79 +138,96 @@ void keyboard_post_init_user(void) {
 #define MODS_CTRL   (get_mods() & MOD_MASK_CTRL)
 #define MODS_ALT    (get_mods() & MOD_MASK_ALT)
 
+void send_string_without_mods(const char *string) {
+    uint8_t mod_state = get_mods();
+    unregister_mods(mod_state);
+    SEND_STRING(string);
+    register_mods(mod_state);
+}
+
 bool process_record_user(uint16_t keycode, keyrecord_t *record) {
     static uint32_t key_timer;
 
     switch (keycode) {
-        case A_AC_LOW: // Lowercase a with acute accent: ALT + 0225
+        case A_ACUTE:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_2) SS_TAP(X_KP_5)));
+                if (MODS_SHIFT) { // Uppercase A with acute accent: ALT + 0193
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_1) SS_TAP(X_KP_9) SS_TAP(X_KP_3)));
+                } else {          // Lowercase a with acute accent: ALT + 0225
+                    SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_2) SS_TAP(X_KP_5)));
+                }
             }
+            layer_off(3);
             return false;
-        case A_AC_CAP: // Uppercase A with acute accent: ALT + 0193
+        case E_ACUTE:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_1) SS_TAP(X_KP_9) SS_TAP(X_KP_3)));
+                if (MODS_SHIFT) { // Uppercase E with acute accent: ALT + 0201
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_0) SS_TAP(X_KP_1)));
+                } else {          // Lowercase e with acute accent: ALT + 0233
+                    SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_3) SS_TAP(X_KP_3)));
+                }
             }
+            layer_off(3);
             return false;
-        case E_AC_LOW: // Lowercase e with acute accent: ALT + 0233
+        case I_ACUTE:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_3) SS_TAP(X_KP_3)));
+                if (MODS_SHIFT) { // Uppercase I with acute accent: ALT + 0205
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_0) SS_TAP(X_KP_5)));
+                } else {          // Lowercase i with acute accent: ALT + 0237
+                    SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_3) SS_TAP(X_KP_7)));
+                }
             }
+            layer_off(3);
             return false;
-        case E_AC_CAP: // Uppercase E with acute accent: ALT + 0201
+        case O_ACUTE:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_0) SS_TAP(X_KP_1)));
+                if (MODS_SHIFT) { // Uppercase O with acute accent: ALT + 0211
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_1) SS_TAP(X_KP_1)));
+                } else {          // Lowercase o with acute accent: ALT + 0243
+                    SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_4) SS_TAP(X_KP_3)));
+                }
             }
+            layer_off(3);
             return false;
-        case I_AC_LOW: // Lowercase i with acute accent: ALT + 0237
+        case U_ACUTE:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_3) SS_TAP(X_KP_7)));
+                if (MODS_SHIFT) { // Uppercase U with acute accent: ALT + 0218
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_1) SS_TAP(X_KP_8)));
+                } else {          // Lowercase u with acute accent: ALT + 0250
+                    SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_5) SS_TAP(X_KP_0)));
+                }
             }
+            layer_off(3);
             return false;
-        case I_AC_CAP: // Uppercase I with acute accent: ALT + 0205
+        case ENE:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_0) SS_TAP(X_KP_5)));
+                if (MODS_SHIFT) { // Uppercase N with tilde accent: ALT + 0209
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_0) SS_TAP(X_KP_9)));
+                } else {          // Lowercase n with tilde accent: ALT + 0241
+                    SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_4) SS_TAP(X_KP_1)));
+                }
             }
+            layer_off(3);
             return false;
-        case O_AC_LOW: // Lowercase o with acute accent: ALT + 0243
+        case INV_EXC:
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_4) SS_TAP(X_KP_3)));
+                if (MODS_SHIFT) { // Inverted exclamation point: ALT + 161
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_1) SS_TAP(X_KP_6) SS_TAP(X_KP_1)));
+                } else {
+                    SEND_STRING("1");
+                }
             }
-            return false;
-        case O_AC_CAP: // Uppercase O with acute accent: ALT + 0211
-            if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_1) SS_TAP(X_KP_1)));
-            }
-            return false;
-        case U_AC_LOW: // Lowercase u with acute accent: ALT + 0250
-            if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_5) SS_TAP(X_KP_0)));
-            }
-            return false;
-        case U_AC_CAP: // Uppercase U with acute accent: ALT + 0218
-            if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_1) SS_TAP(X_KP_8)));
-            }
-            return false;
-        case ENE_LOW: // Lowercase n with tilde accent: ALT + 0241
-            if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_4) SS_TAP(X_KP_1)));
-            }
-            return false;
-        case ENE_CAP: // Uppercase N with tilde accent: ALT + 0209
-            if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_2) SS_TAP(X_KP_0) SS_TAP(X_KP_9)));
-            }
-            return false;
-        case INV_EXC: // Inverted exclamation point: ALT + 161
-            if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_1) SS_TAP(X_KP_6) SS_TAP(X_KP_1)));
-            }
+            layer_off(3);
             return false;
         case INV_QUS: // Inverted question mark: ALT + 191
             if (record->event.pressed) {
-                SEND_STRING(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_1) SS_TAP(X_KP_9) SS_TAP(X_KP_1)));
+                if (MODS_SHIFT) {
+                    send_string_without_mods(SS_LALT(SS_TAP(X_KP_0) SS_TAP(X_KP_1) SS_TAP(X_KP_9) SS_TAP(X_KP_1)));
+                } else {
+                    SEND_STRING("/");
+                }
             }
+            layer_off(3);
             return false;
         // DEFAULTS BELOW
         case U_T_AUTO:


### PR DESCRIPTION
* Activate Spanish layers by double tapping LEFT ALT instead of holding CAPS LOCK. 
* Add cyan indicator light for Spanish layers
* Merge Spanish layers by making better use of macros
* Automatically turn off Spanish layer after typing a Spanish letter