### PR TITLE
v4.4.1 Windows Shortcut Timing Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add audio output device LED indicators
-  - A number key (<kbd>1</kbd>–<kbd>9</kbd>) will be backlit corresponding with the selected device for one second following a change
+  - A number key (<kbd>1</kbd>–<kbd>9</kbd>) will be backlit corresponding with the selected device for one second
+    following a change
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.1] - 2026-04-30
+
+### Fixed
+
+- Over time, Windows has gotten slower and the 50ms delay between <kbd>Win</kbd>+<kbd>r</kbd> and entering a command
+  is no longer long enough. Increase delay from 50 ms to 100 ms.
+- Increase delay on audio output toggle from 200 ms to 250 ms for same reason
+
 ## [4.4.0] - 2025-09-19
 
 ### Added
@@ -224,6 +232,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - This CHANGELOG file
 - gitignore
 
+[4.4.1]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v4.4.0...v4.4.1
 [4.4.0]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v4.3.0...v4.4.0
 [4.3.0]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v4.2.2...v4.3.0
 [4.2.2]: https://github.com/jgmortim/massdrop-ctrl-keymap/compare/v4.2.1...v4.2.2

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ power to all connected devices.
 
 * The images in this README were created using [Keyboard Layout Editor v0.15](https://www.keyboard-layout-editor.com/). 
   The specific JSON needed to recreate these images can be found under `/resources/json/`.
-* Each time this README mentions the color of an LED, a colored square is displayed. These image ares sourced from
+* Each time this README mentions the color of an LED, a colored square is displayed. These images are sourced from
   [Placehold](https://placehold.co).
   * Note: The color codes used in this README are different from the codes actually driving the LEDs. This is because
     the LEDs on the keyboard are not very color accurate. The color codes in this README are approximations of the

--- a/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/keymap.c
+++ b/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/keymap.c
@@ -328,7 +328,7 @@ bool process_record_user(uint16_t keycode, keyrecord_t *record) {
         case KC_A:
             if (record->event.pressed && MODS_GUI && os_mode == WINDOWS) {
                 audio_output = (audio_output + 1) % NUMBER_OF_AUDIO_OUTPUT_DEVICES; // Increment to the next device.
-                SEND_STRING(SS_LGUI(SS_LCTL("v")) SS_DELAY(200)); // Open the sound output page of quick settings.
+                SEND_STRING(SS_LGUI(SS_LCTL("v")) SS_DELAY(250)); // Open the sound output page of quick settings.
                 for (int i = 0; i < audio_output; i++) {
                     SEND_STRING(SS_TAP(X_DOWN)); // Press the down arrow until the appropriate device is highlighted.
                 }

--- a/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/windows_functions.c
+++ b/qmk_firmware/keyboards/massdrop/ctrl/jgmortim/windows_functions.c
@@ -27,11 +27,11 @@ static const char *const numpad_key_taps[] = {
 
 /* Opens the Windows Run dialog and enters the given command. */
 void windows_run(const char *command) {
-    if (!command || !*command) return;      // Skip if input is empty.
+    if (!command || !*command) return;       // Skip if input is empty.
 
-    SEND_STRING(SS_LGUI("r") SS_DELAY(50)); // Open the run dialog,
-    SEND_STRING(command);                   // type in the command,
-    SEND_STRING(SS_TAP(X_ENT));             // and press enter.
+    SEND_STRING(SS_LGUI("r") SS_DELAY(100)); // Open the run dialog,
+    SEND_STRING(command);                    // type in the command,
+    SEND_STRING(SS_TAP(X_ENT));              // and press enter.
 }
 
 /* Executes the given alt code. */


### PR DESCRIPTION
## Fixed

- Over time, Windows has gotten slower and the 50ms delay between <kbd>Win</kbd>+<kbd>r</kbd> and entering a command
  is no longer long enough. Increase delay from 50 ms to 100 ms.
- Increase delay on audio output toggle from 200 ms to 250 ms for same reason